### PR TITLE
Fix issue where layout was not parsing yaml front matter.

### DIFF
--- a/lib/jekyll-haml/ext/convertible.rb
+++ b/lib/jekyll-haml/ext/convertible.rb
@@ -4,13 +4,16 @@
 
 module Jekyll
   class Layout
-    def content
-      if ext == '.haml' && @converted != true
-        @content   = ::Haml::Engine.new(@content).render
-        @converted = true
-      else
-        @content
-      end
+    def initialize(site, base, name)
+      @site = site
+      @base = base
+      @name = name
+
+      self.data = {}
+
+      self.process(name)
+      self.read_yaml(base, name)
+      self.transform
     end
   end
 end


### PR DESCRIPTION
As .read_yaml was using self.content the haml template is stripped of it's yaml front matter before it can be processed in .read_yaml.

By simply calling .transform after .read_yaml it converts the layout AFTER the front matter yaml has been processed.
