### PR TITLE
DRY up monkey patch of Jekyll::Layout

### DIFF
--- a/lib/jekyll-haml/ext/convertible.rb
+++ b/lib/jekyll-haml/ext/convertible.rb
@@ -1,18 +1,11 @@
 # Re-open Layout class to convert our HAML Layout content.
-# This solution risks Jekyll API updates, and potential
-# interference from other included plugins.
 
 module Jekyll
   class Layout
-    def initialize(site, base, name)
-      @site = site
-      @base = base
-      @name = name
+    alias old_initialize initialize
 
-      self.data = {}
-
-      self.process(name)
-      self.read_yaml(base, name)
+    def initialize(*args)
+      old_initialize(*args)
       self.transform
     end
   end


### PR DESCRIPTION
This uses an method alias instead of copying the whole code of #initialize.

As seen on https://github.com/hanchang/haml-jekyll/blob/master/_plugins/transform_layouts.rb

I think this is much more stable in terms of future API updates (unless e.g. #transform gets renamed).