### PR TITLE
Follow Jekyll 2.3.0 internal API change

### DIFF
--- a/lib/jekyll-haml/ext/convertible.rb
+++ b/lib/jekyll-haml/ext/convertible.rb
@@ -13,7 +13,7 @@ module Jekyll
 
       self.process(name)
       self.read_yaml(base, name)
-      self.transform
+      self.content = self.transform
     end
   end
 end


### PR DESCRIPTION
`Jekyll::Convertible#transform` now returns a transformed content, doesn't update `self.content` any longer.

Changed in jekyll/jekyll@d004bc4ea507189111e7d93f4e64a09815a6e185.