### PR TITLE
Fixed an error with Jekyll 2.3.0 (and probably with prior versions) that crashes when building the site

### DIFF
--- a/lib/jekyll-haml/ext/convertible.rb
+++ b/lib/jekyll-haml/ext/convertible.rb
@@ -1,19 +1,13 @@
 # Re-open Layout class to convert our HAML Layout content.
-# This solution risks Jekyll API updates, and potential
-# interference from other included plugins.
+# This solution redeclares the Layout class in a way that 
+# don't risks Jekyll API updates anymore.
 
 module Jekyll
-  class Layout
-    def initialize(site, base, name)
-      @site = site
-      @base = base
-      @name = name
-
-      self.data = {}
-
-      self.process(name)
-      self.read_yaml(base, name)
-      self.transform
+  class << Layout
+    alias old_initialize initialize
+    def initialize(*args)
+      old_initialize(*args)
+      self.content = self.transform
     end
   end
 end


### PR DESCRIPTION
I was getting this error:

```
jekyll 2.3.0 | Error:  undefined local variable or method `path' for #<Jekyll::Layout:0x007fda29134420>
```
Fixed by correctly redeclaring the Layout class inheriting by the original one.

@yaegashi and @felixkiss solutions are integrated as well.
