### PR TITLE
README: break apart examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,28 +18,46 @@ In a file within your Jekyll project's `_plugins` directory:
 
 ## Usage
 
-You'll be able to use all of Haml's tricks to write some really clean markup. You can use liquid filters easily by just rendering the liquid tags as shown below. The gem adds the liquid filter `haml` so you can render `_includes` that are written in Haml as well. Have fun!
-
-For clean content blocks, I find it helps to use Haml's `:markdown` filter if I can get away with it.
+You'll be able to use all of Haml's tricks to write some really clean markup. You can use liquid filters easily by just rendering the liquid tags as shown below. Have fun!
 
 ```haml
 ---
 title: Story Time
 permalink: page/
 ---
+.container
+  %h3= "{% title %}"
+  
 :javascript
   $(document).ready(function(){});
+```
 
-%h3= "{% title %}"
+### Markdown blocks
+
+For clean content blocks, I find it helps to use Haml's `:markdown` filter if I can get away with it.
+
+```haml
 .content
   :markdown
     *Dec 4, 2012* - [Author](http://github.com)
 
     Once upon a time, in a village by the sea...
+```
+    
+### Partials
 
-= "{% haml comments.haml %}"
+The gem adds the liquid filter `haml` so you can render `_includes` that are written in Haml as well. 
+
+```liquid
+{% haml comments.haml %}
 ```
 
+ ```haml
+-# _includes/meta.haml
+%meta{property: 'og:type', content: 'website'}
+%meta{name: 'viewport', content: 'width=device-width'}
+ ```
+ 
 ## About
 
 I originally searched around the internet for a quick way to integrate HAML into my jekyll workflow and found a few around the internet to convert haml in different cases (layouts, partials, and posts). This gem is really just a collection of those techniques so they're easy to find and you can get back to creating your site using the slickest markup. It's made to drop in to your `Gemfile` just as easily as [jekyll-sass](https://github.com/noct/jekyll-sass).


### PR DESCRIPTION
I found myself struggling to figure out how to use partials. It turns out the README does show the syntax in one line of the example. I found this one large example a little hard to digest: I thought it was demo'ing one feature (markdown blocks), but it turns out its demoing all features.

I broke it apart into 3 examples to be easier to understand.