### PR TITLE
Method 'haml' loops through "includes_load_paths"

### DIFF
--- a/lib/jekyll-haml/tags/haml_partial.rb
+++ b/lib/jekyll-haml/tags/haml_partial.rb
@@ -1,4 +1,5 @@
 require 'haml'
+require 'pp'
 
 module Jekyll
 
@@ -9,11 +10,7 @@ module Jekyll
     end
 
     def render(context)
-      includes_dir = File.join(context.registers[:site].source, '_includes')
-
-      if File.symlink?(includes_dir)
-        return "Includes directory '#{includes_dir}' cannot be a symlink"
-      end
+      includes_dirs = context.registers[:site].includes_load_paths.map{ |f| File.join(f) }
 
       if @file !~ /^[a-zA-Z0-9_\/\.-]+$/ || @file =~ /\.\// || @file =~ /\/\./
         return "Include file '#{@file}' contains invalid characters or sequences"
@@ -21,28 +18,48 @@ module Jekyll
 
       return "File must have \".haml\" extension" if @file !~ /\.haml$/
 
-      Dir.chdir(includes_dir) do
-        choices = Dir['**/*'].reject { |x| File.symlink?(x) }
-        if choices.include?(@file)
-          source     = File.read(@file)
-          conversion = ::Haml::Engine.new(source).render
-          partial    = Liquid::Template.parse(conversion)
-          begin
-            return partial.render!(context)
-          rescue => e
-            puts "Liquid Exception: #{e.message} in #{self.data["layout"]}"
-            e.backtrace.each do |backtrace|
-              puts backtrace
-            end
-            abort("Build Failed")
-          end
+      haml_file = nil
+      includes_dirs.each do |dir|
 
-          context.stack do
-            return partial.render(context)
-          end
-        else
-          "Included file '#{@file}' not found in _includes directory"
+        if File.symlink?(dir)
+          return "Includes directory '#{dir}' cannot be a symlink"
         end
+
+        if Dir.exists?(dir)
+          Dir.chdir(dir) do
+            choices = Dir['**/*'].reject { |x| File.symlink?(x) }
+            if choices.include?(@file)
+              # Set haml_file to first match,
+              # includes_load_paths returns project's _includes first, then gem's _includes,
+              # so user can override the gem's file.
+              haml_file = File.read(@file)
+            end
+          end
+        end
+
+        break if haml_file
+
+      end
+
+      if haml_file
+        conversion = ::Haml::Engine.new(haml_file).render
+        partial    = Liquid::Template.parse(conversion)
+
+        begin
+          return partial.render!(context)
+        rescue => e
+          puts "Liquid Exception: #{e.message} in #{self.data["layout"]}"
+          e.backtrace.each do |backtrace|
+            puts backtrace
+          end
+          abort("Build Failed")
+        end
+
+        context.stack do
+          return partial.render(context)
+        end
+      else
+        "Included file '#{@file}' not found in _includes directories"
       end
     end
   end


### PR DESCRIPTION
This allows _jekyll-haml_ to be used as a theme gem's dependency by looking for gem's __includes_ folder.
The _file name_ can still be overrided in the local jekyll project.