### PR TITLE
removes newlines from `{% haml %}` includes

### DIFF
--- a/lib/jekyll-haml/tags/haml_partial.rb
+++ b/lib/jekyll-haml/tags/haml_partial.rb
@@ -25,7 +25,7 @@ module Jekyll
         choices = Dir['**/*'].reject { |x| File.symlink?(x) }
         if choices.include?(@file)
           source     = File.read(@file)
-          conversion = ::Haml::Engine.new(source).render
+          conversion = ::Haml::Engine.new(source).render.delete("\n")
           partial    = Liquid::Template.parse(conversion)
           begin
             return partial.render!(context)


### PR DESCRIPTION
Yesterday I stumbled upon the problem that I wasn't able to include files properly in the way I expected. For example, this code:

```
.content
  {% haml portfolio/nav_jobs.haml %}

  %main
    something here
```

Would render as:

```
<div class="content">
  <nav class="left-column" >
<header>
</header>
</nav>
  %main
    something here
```

And as you may see, it would give an error of `Illegal nesting: nesting within plain text is illegal`. Even when I managed to make it work, only `<nav>` would be part of `.content`, the rest would be on top level.

What this simple PR does is stripping newlines so that rendered partials won't enter in the indentation game, making it behave in much more predictable way. 