### PR TITLE
unobfuscate some errors

### DIFF
--- a/lib/jekyll-haml/tags/haml_partial.rb
+++ b/lib/jekyll-haml/tags/haml_partial.rb
@@ -30,7 +30,8 @@ module Jekyll
           begin
             return partial.render!(context)
           rescue => e
-            puts "Liquid Exception: #{e.message} in #{self.data["layout"]}"
+            print "Liquid Exception: #{e.message}"
+            print "in #{self.data["layout"]}"
             e.backtrace.each do |backtrace|
               puts backtrace
             end


### PR DESCRIPTION
I was having this error:
```
Liquid Exception: undefined method `data' for #<Jekyll::HamlPartialTag:0x007ffa658eb1f8> in portfolio.coffee
```

That wasn't the original error from my side, but actually an error from the error message while trying to access the method `data` inside a partial. That was obfuscating the true error from my side.

So solved this by breaking the error message in 2 different lines. Its not the perfect fix, but its better than the current.