### PR TITLE
Liquid interpolation and relative partial include

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ permalink: page/
 ---
 .container
   %h3= "{% title %}"
-  
+
 :javascript
   $(document).ready(function(){});
 ```
@@ -47,10 +47,10 @@ For clean content blocks, I find it helps to use Haml's `:markdown` filter if I 
 
     Once upon a time, in a village by the sea...
 ```
-    
+
 ### Partials
 
-The gem adds the liquid filter `haml` so you can render `_includes` that are written in Haml as well. 
+The gem adds the liquid filter `haml` so you can render `_includes` that are written in Haml as well.
 
 ```liquid
 {% haml comments.haml %}
@@ -61,7 +61,19 @@ The gem adds the liquid filter `haml` so you can render `_includes` that are wri
 %meta{property: 'og:type', content: 'website'}
 %meta{name: 'viewport', content: 'width=device-width'}
  ```
- 
+
+If you wanna render includes outside the `_includes` folder, that's fine:
+
+```liquid
+{% haml my_neat_folder/my_include.haml relative:true %}
+```
+
+Also, don't shy away from using liquid interpolation:
+
+```
+{% haml "{{ page.author }}".haml %}
+```
+
 ## About
 
 I originally searched around the internet for a quick way to integrate HAML into my jekyll workflow and found a few around the internet to convert haml in different cases (layouts, partials, and posts). This gem is really just a collection of those techniques so they're easy to find and you can get back to creating your site using the slickest markup. It's made to drop in to your `Gemfile` just as easily as [jekyll-sass](https://github.com/noct/jekyll-sass).

--- a/lib/jekyll-haml/tags/haml_partial.rb
+++ b/lib/jekyll-haml/tags/haml_partial.rb
@@ -3,51 +3,68 @@ require 'haml'
 module Jekyll
 
   class HamlPartialTag < Liquid::Tag
-    def initialize(tag_name, file, tokens)
+    def initialize(tag_name, user_string, tokens)
       super
-      @file = file.strip
+      @user_string = user_string
     end
 
     def render(context)
+      @user_string = Liquid::Template.parse(@user_string)
+                                     .render(context)
+                                     .gsub(%r{\"|\'},'')
+                                     .strip
+
+      file, arg = @user_string.split(' ')
+      relative  = arg.nil? ? false : !!(arg =~ /true/)
+
       includes_dir = File.join(context.registers[:site].source, '_includes')
 
       if File.symlink?(includes_dir)
         return "Includes directory '#{includes_dir}' cannot be a symlink"
       end
 
-      if @file !~ /^[a-zA-Z0-9_\/\.-]+$/ || @file =~ /\.\// || @file =~ /\/\./
-        return "Include file '#{@file}' contains invalid characters or sequences"
+      if file !~ /^[a-zA-Z0-9_\/\.-]+$/ || file =~ /\.\// || file =~ /\/\./
+        return "Include file '#{file}' contains invalid characters or sequences"
       end
 
-      return "File must have \".haml\" extension" if @file !~ /\.haml$/
+      return "File must have \".haml\" extension" if file !~ /\.haml$/
 
-      Dir.chdir(includes_dir) do
-        choices = Dir['**/*'].reject { |x| File.symlink?(x) }
-        if choices.include?(@file)
-          source     = File.read(@file)
-          conversion = ::Haml::Engine.new(source).render.delete("\n")
-          partial    = Liquid::Template.parse(conversion)
-          begin
-            return partial.render!(context)
-          rescue => e
-            print "Liquid Exception: #{e.message}"
-            print "in #{self.data["layout"]}"
-            e.backtrace.each do |backtrace|
-              puts backtrace
-            end
-            abort("Build Failed")
+      if relative
+        include_file(file, context)
+      else
+        Dir.chdir(includes_dir) do
+          choices = Dir['**/*'].reject { |x| File.symlink?(x) }
+          if choices.include?(file)
+            include_file(file, context)
+          else
+            "Included file '#{file}' not found in _includes directory"
           end
-
-          context.stack do
-            return partial.render(context)
-          end
-        else
-          "Included file '#{@file}' not found in _includes directory"
         end
       end
     end
-  end
 
+    private
+
+    def include_file(file, context)
+      source     = File.read(file)
+      conversion = ::Haml::Engine.new(source).render.delete("\n")
+      partial    = Liquid::Template.parse(conversion)
+      begin
+        return partial.render!(context)
+      rescue => e
+        print "Liquid Exception: #{e.message}"
+        print "in #{self.data["layout"]}"
+        e.backtrace.each do |backtrace|
+          puts backtrace
+        end
+        abort("Build Failed")
+      end
+
+      context.stack do
+        return partial.render(context)
+      end
+    end
+  end
 end
 
 Liquid::Template.register_tag('haml', Jekyll::HamlPartialTag)

--- a/lib/jekyll-haml/tags/haml_partial.rb
+++ b/lib/jekyll-haml/tags/haml_partial.rb
@@ -30,7 +30,8 @@ module Jekyll
           begin
             return partial.render!(context)
           rescue => e
-            puts "Liquid Exception: #{e.message} in #{self.data["layout"]}"
+            print "Liquid Exception: #{e.message}"
+            print "in #{self.data["layout"]}"
             e.backtrace.each do |backtrace|
               puts backtrace
             end


### PR DESCRIPTION
This PR allows for having `{{ }}` interpolation on the `{% haml %}` tag.

It also allows for:
{% haml relative:true %}

That will enable developers to include files outside the `_includes` folder.