### PR TITLE
_renderer does not exist anymore in jekyll

### DIFF
--- a/lib/jekyll-haml/ext/convertible.rb
+++ b/lib/jekyll-haml/ext/convertible.rb
@@ -9,7 +9,7 @@ module Jekyll
     end
 
     def transform
-      _renderer.convert(content)
+      renderer.convert(content)
     end
 
     def extname


### PR DESCRIPTION
```
/home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-haml-0.1.6/lib/jekyll-haml/ext/convertible.rb:12:in `transform': undefined local variable or method `_renderer' for #<Jekyll::Layout:0x000055f313efc6b0> (NameError)
Did you mean?  renderer
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-haml-0.1.6/lib/jekyll-haml/ext/convertible.rb:8:in `initialize'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-4.1.1/lib/jekyll/readers/layout_reader.rb:15:in `new'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-4.1.1/lib/jekyll/readers/layout_reader.rb:15:in `block in read'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-4.1.1/lib/jekyll/readers/layout_reader.rb:13:in `each'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-4.1.1/lib/jekyll/readers/layout_reader.rb:13:in `read'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-4.1.1/lib/jekyll/reader.rb:15:in `read'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-4.1.1/lib/jekyll/site.rb:180:in `read'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-4.1.1/lib/jekyll/site.rb:78:in `process'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-4.1.1/lib/jekyll/command.rb:28:in `process_site'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-4.1.1/lib/jekyll/commands/build.rb:65:in `build'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-4.1.1/lib/jekyll/commands/build.rb:36:in `process'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-4.1.1/lib/jekyll/command.rb:91:in `block in process_with_graceful_fail'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-4.1.1/lib/jekyll/command.rb:91:in `each'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-4.1.1/lib/jekyll/command.rb:91:in `process_with_graceful_fail'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-4.1.1/lib/jekyll/commands/serve.rb:86:in `block (2 levels) in init_with_program'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in `block in execute'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in `each'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in `execute'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/mercenary-0.4.0/lib/mercenary/program.rb:44:in `go'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/mercenary-0.4.0/lib/mercenary.rb:21:in `program'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-4.1.1/exe/jekyll:15:in `<top (required)>'
	from /home/klaus/.rbenv/versions/2.7.1/bin/jekyll:23:in `load'
	from /home/klaus/.rbenv/versions/2.7.1/bin/jekyll:23:in `<top (required)>'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `load'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `kernel_load'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:28:in `run'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/cli.rb:476:in `exec'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/cli.rb:30:in `dispatch'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/cli.rb:24:in `start'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/exe/bundle:46:in `block in <top (required)>'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:123:in `with_friendly_errors'
	from /home/klaus/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/exe/bundle:34:in `<top (required)>'
	from /home/klaus/.rbenv/versions/2.7.1/bin/bundle:23:in `load'
	from /home/klaus/.rbenv/versions/2.7.1/bin/bundle:23:in `<main>'
```

Fix for newer version of jekyll. 